### PR TITLE
Allow a bypass to be set by the application

### DIFF
--- a/src/RewriterHttpModule.cs
+++ b/src/RewriterHttpModule.cs
@@ -52,7 +52,16 @@ namespace Intelligencia.UrlRewriter
         {
             // Add our PoweredBy header
             // HttpContext.Current.Response.AddHeader(Constants.HeaderXPoweredBy, Configuration.XPoweredBy);
-
+            
+            // Allow a bypass to be set up by the using application
+            HttpContext context = HttpContext.Current;
+            if (context.Items.Contains(@"Intelligencia.UrlRewriter.Bypass") && 
+                context.Items[@"Intelligencia.UrlRewriter.Bypass"] is bool && 
+                ((bool)context.Items[@"Intelligencia.UrlRewriter.Bypass"]))
+            {
+                // A bypass is set!
+                return;
+            }
             _rewriter.Rewrite();
         }
 


### PR DESCRIPTION
Allow a bypass to be set by the application.
using HttpContext.Items[@"Intelligencia.UrlRewriter.Bypass"] = true

I use this many time when I have an advanced application that is doing real neat stuff :-)
I found that odd that it still was not added to official Intelligencia.
